### PR TITLE
Use static version for glob package

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "connect-ratelimit": "git://github.com/dharmafly/connect-ratelimit.git#0550eff209c54f35078f46445000797fa942ab97",
     "cron": "^1.0.4",
     "express": "~3.4.7",
-    "glob": "*",
+    "glob": "7.1.4",
     "leveldown": "~0.10.0",
     "levelup": "~0.19.0",
     "lodash": "^2.4.1",


### PR DESCRIPTION
resolves following error: 

```
$HOME/chipssight/node_modules/insight-bitcore-api/node_modules/glob/node_modules/minimatch/minimatch.js:1
_dirname) { const minimatch = module.exports = (p, pattern, options = {}) => {
                                                                           ^
SyntaxError: Unexpected token >
```

Unspecified `glob` package version was pulling in an incompatible version for `minimatch`.  With this change, things run as they should.