### PR TITLE
Resolve error in instances where we have zero-value transfers, or unparsed addresses

### DIFF
--- a/lib/TransactionDb.js
+++ b/lib/TransactionDb.js
@@ -190,7 +190,7 @@ TransactionDb.prototype._fillOutpoints = function(txInfo, cb) {
 
   async.eachLimit(txInfo.vin, CONCURRENCY, function(i, c_in) {
       self.fromTxIdN(i.txid, i.vout, function(err, ret) {
-        if (!ret || !ret.addr || !ret.valueSat) {
+        if (!ret || !ret.addr) {
           logger.info('Could not get TXouts in %s,%d from %s ', i.txid, i.vout, txInfo.txid);
           if (ret) i.unconfirmedInput = ret.unconfirmedInput;
           incompleteInputs = 1;

--- a/lib/TransactionDb.js
+++ b/lib/TransactionDb.js
@@ -190,7 +190,9 @@ TransactionDb.prototype._fillOutpoints = function(txInfo, cb) {
 
   async.eachLimit(txInfo.vin, CONCURRENCY, function(i, c_in) {
       self.fromTxIdN(i.txid, i.vout, function(err, ret) {
-        if (!ret || !ret.addr) {
+        if (!ret /*|| !ret.addr || !ret.valueSat*/) {
+          // Conditions above were not recognizing 0sat value transfers, nor OP_RET scripts
+          // This fix is incomplete, but will investigate further. But now displays values = 0 CHIPS
           logger.info('Could not get TXouts in %s,%d from %s ', i.txid, i.vout, txInfo.txid);
           if (ret) i.unconfirmedInput = ret.unconfirmedInput;
           incompleteInputs = 1;


### PR DESCRIPTION
Prior to this commit, chipssight was printing errors:

`info: Could not get TXouts in %s,%d from %s`

For transaction with hash: `5e8c27f0426d09f2d001ef67602eb54481a675b5bb69a6993d7afac26f472393`... i.e. when visiting https://explorer.chips.cash/tx/5e8c27f0426d09f2d001ef67602eb54481a675b5bb69a6993d7afac26f472393

This change does not appear to fix improper displaying of address(es), but at least resolves the error in question.